### PR TITLE
workflow: Add cargo publish to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -76,3 +76,13 @@ jobs:
           asset_name: '${{ steps.rename_crate.outputs.asset_name }}'
           asset_path: '${{ steps.rename_crate.outputs.asset_path }}'
           upload_url: '${{ steps.create_release.outputs.upload_url }}'
+      # Finally, publish to crates.io
+      # We don't verify the publish here, as we verified as part of the dry-run
+      # above.
+      - name: 'Publish to Crates.io'
+        uses: 'actions-rs/cargo@v1'
+        env:
+          CARGO_REGISTRY_TOKEN: '${{ secrets.CARGO_TOKEN }}'
+        with:
+          command: 'publish'
+          args: '--no-verify'


### PR DESCRIPTION
Adds cargo publish to release workflow before v1.0.0.

We don't verify here as verification of the code was performed as part
of the dry-run.