### PR TITLE
workflows: Change the release changelog path

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,7 +43,7 @@ jobs:
         id: 'generate_changelog'
         run: |
           VERSION="$(basename ${{ github.ref }})"
-          OUTPUT="release_changelog.md"
+          OUTPUT="/tmp/release_changelog.md"
 
           # Add changelog for version
           sed -n "/## ${VERSION}/,/^##/p;" CHANGELOG.md \


### PR DESCRIPTION
This prevents the generated changelog being dumped in the source code
directory, which cargo publish does not like.